### PR TITLE
Update workflows jobs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,6 +55,20 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Test
+        run: go test -v ./...
+
+  test-1_19:
+    name: Test 1.19
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Test
         run: go test -v ./... -coverprofile=coverage.txt -covermode=atomic
 
       - name: Codecov

--- a/.github/workflows/golangci-lint-latest.yml
+++ b/.github/workflows/golangci-lint-latest.yml
@@ -8,10 +8,16 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+          check-latest: true
+        id: go
       - name: Check out code
         uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.3.0
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           args: -c .golangci.yml -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,10 +5,16 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+          check-latest: true
+        id: go
       - name: Check out code
         uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.3.0
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50
           args: -c .golangci.yml -v


### PR DESCRIPTION
* use major version to run golangci/golangci-lint-action and setup go before run linters
* add go 1.19 tests