### PR TITLE
golang v1.21

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,6 +83,20 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Test
+        run: go test -race -v ./...
+
+  test-1_21:
+    name: Test 1.21
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Test
         run: go test -race -v ./... -coverprofile=coverage.out -covermode=atomic
 
       - name: Codecov

--- a/.github/workflows/golangci-lint-latest.yml
+++ b/.github/workflows/golangci-lint-latest.yml
@@ -8,10 +8,10 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
           check-latest: true
         id: go
       - name: Check out code

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,10 +5,10 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
           check-latest: true
         id: go
       - name: Check out code
@@ -16,5 +16,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53
+          version: v1.54
           args: -c .golangci.yml -v


### PR DESCRIPTION
- workflows: test with golang v1.21
- tests: bump golangci-lint to v1.54